### PR TITLE
Bump version so dependancies change

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "thaw.js",
   "main": "thaw.js",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "homepage": "https://github.com/robertleeplummerjr/thaw.js",
   "authors": [
     "Robert Plummer <robertleeplummerjr@gmail.com> (http://visop-dev.com)"


### PR DESCRIPTION
Even after removing the testify dependancy in the last commit, it still exists because the package version wasn't bumped is my guess

This is from a fresh install
```
{
  "name": "thaw.js",
  "main": "thaw.js",
  "version": "1.2.1",
  "homepage": "https://github.com/robertleeplummerjr/thaw.js",
  "authors": [
    "Robert Plummer <robertleeplummerjr@gmail.com> (http://visop-dev.com)"
  ],
  "description": "synthetic asynchronous processing in javascript",
  "keywords": [
    "asynchronous",
    "processing",
    "fast",
    "web",
    "worker"
  ],
  "license": "MIT",
  "ignore": [
    "**/.*",
    "node_modules",
    "bower_components",
    "test",
    "tests"
  ],
  "dependencies": {
    "testify.js": "*"
  }
}
```